### PR TITLE
Replace print with logging

### DIFF
--- a/src/monaco/__init__.py
+++ b/src/monaco/__init__.py
@@ -2,6 +2,10 @@
 from importlib import metadata
 __version__ = metadata.version(__name__)
 
+# Lightweight logging setup: attach a NullHandler so library logging is opt-in
+import logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 from monaco.mc_case import *
 from monaco.mc_sim import *
 from monaco.mc_var import *

--- a/src/monaco/helper_functions.py
+++ b/src/monaco/helper_functions.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import warnings
+import logging
 import numpy as np
 from operator import itemgetter
 from tqdm import tqdm
@@ -251,7 +252,12 @@ def vprint(verbose : bool, *args, **kwargs) -> None:
         Must include something to print here!
     """
     if verbose:
-        print(*args, **kwargs)
+        logger = logging.getLogger('monaco')
+        # Join args to string similarly to print default behavior
+        sep = kwargs.get('sep', ' ')
+        end = kwargs.get('end', '\n')
+        msg = sep.join(str(a) for a in args) + ('' if end == '' else '')
+        logger.info(sep.join(str(a) for a in args))
 
 
 def warn_short_format(message, category, filename, lineno, file=None, line=None) -> str:
@@ -273,6 +279,13 @@ def vwarn(verbose : bool, *args, **kwargs) -> None:
         Must include a warning message here!
     """
     if verbose:
+        logger = logging.getLogger('monaco')
+        # Log warning as well as emit warnings.warn with short format
+        try:
+            message = args[0] if args else ''
+            logger.warning(message)
+        except Exception:
+            pass
         warn_default_format = warnings.formatwarning
         warnings.formatwarning = warn_short_format  # type: ignore
         warnings.warn(*args, **kwargs)
@@ -308,7 +321,8 @@ def timeit(fcn : Callable):
         t0 = time()
         output = fcn(*args, **kw)
         t1 = time()
-        print(f'"{fcn.__name__}" took {(t1 - t0)*1000 : .3f} ms to execute.\n')
+        logger = logging.getLogger('monaco')
+        logger.info(f'"{fcn.__name__}" took {(t1 - t0)*1000 : .3f} ms to execute.')
         return output
     return timed
 

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -2,6 +2,7 @@
 
 import pytest
 import time
+import logging
 import numpy as np
 from monaco.helper_functions import (next_power_of_2, hash_str_repeatable, is_num,
                                      length, get_list, slice_by_index, empty_list,
@@ -107,18 +108,17 @@ def test_flatten():
            == ['test', 0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 
-def test_timeit(capsys):
+def test_timeit(caplog):
     @timeit
     def test_function(x, y=1):
         time.sleep(0.001)
         return x + y
 
-    result = test_function(5, y=3)
-    assert result == 8
-
-    captured = capsys.readouterr()
-    assert '"test_function" took' in captured.out
-    assert 'ms to execute' in captured.out
+    with caplog.at_level(logging.INFO, logger='monaco'):
+        result = test_function(5, y=3)
+        assert result == 8
+    assert '"test_function" took' in caplog.text
+    assert 'ms to execute' in caplog.text
 
 
 def test_hashable_val_vectorized_base_path():


### PR DESCRIPTION
Switch from print statements to Python's logging module for better adherence to best practices and flexible output handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-7736ef65-035a-43b2-a554-91fc3c0e826d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7736ef65-035a-43b2-a554-91fc3c0e826d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

