### PR TITLE
Replace print with logging

### DIFF
--- a/docs/images/volume_of_hypersphere.py
+++ b/docs/images/volume_of_hypersphere.py
@@ -1,4 +1,5 @@
 import math
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -8,9 +9,10 @@ k = list(range(1, 11))
 v0 = [1 for x in k]
 v1 = [1/np.math.factorial(x) for x in k]
 v2 = [np.pi**(x/2)/(2**x * math.gamma(x/2+1)) for x in k]
-print(k)
-print(v1)
-print(v2)
+logger = logging.getLogger(__name__)
+logger.info(k)
+logger.info(v1)
+logger.info(v2)
 
 fig, ax = plt.subplots(1, 1)
 ax.semilogy(k, v0, '-*', c='k')

--- a/examples/election/election_example_monte_carlo_sim.py
+++ b/examples/election/election_example_monte_carlo_sim.py
@@ -1,4 +1,5 @@
 from scipy.stats import norm, uniform
+import logging
 import monaco as mc
 import matplotlib.pyplot as plt
 import numpy as np
@@ -57,14 +58,17 @@ def election_example_monte_carlo_sim():
     pct_dem_win = sum(x == 'Dem' for x in sim.outvars['Winner'].vals)/sim.ncases
     pct_rep_win = sum(x == 'Rep' for x in sim.outvars['Winner'].vals)/sim.ncases
     pct_contested = sum(x == 'Contested' for x in sim.outvars['Winner'].vals)/sim.ncases
-    print(f'Win probabilities: {100*pct_dem_win:0.1f}% Dem, ' +
-                             f'{100*pct_rep_win:0.1f}% Rep, ' +
-                             f'{100*pct_contested:0.1f}% Contested')
+    logger = logging.getLogger(__name__)
+    logger.info(
+        f'Win probabilities: {100*pct_dem_win:0.1f}% Dem, '
+        f'{100*pct_rep_win:0.1f}% Rep, '
+        f'{100*pct_contested:0.1f}% Contested')
     mc.plot(sim.outvars['Winner'])
 
     pct_recount = sum(x != 0 for x in sim.outvars['Num Recounts'].vals)/sim.ncases
-    print(f'In {100*pct_recount:0.1f}% of runs there was a state close enough ' +
-           'to trigger a recount (<0.5%)')
+    logger.info(
+        f'In {100*pct_recount:0.1f}% of runs there was a state close enough '
+        'to trigger a recount (<0.5%)')
 
     dem_win_state_pct = dict()
     for state in states:

--- a/examples/integration/integration_example_monte_carlo_sim.py
+++ b/examples/integration/integration_example_monte_carlo_sim.py
@@ -1,4 +1,5 @@
 from scipy.stats import uniform
+import logging
 import monaco as mc
 import numpy as np
 
@@ -50,18 +51,19 @@ firstcaseismedian = False
 error = 0.01
 conf = 0.95
 stdev = mc.max_stdev(low=0, high=1)
-print(f'Maximum possible standard deviation: {stdev:0.3f}')
+logger = logging.getLogger(__name__)
+logger.info(f'Maximum possible standard deviation: {stdev:0.3f}')
 
 nRandom = mc.integration_n_from_err(error=error, dimension=dimension, volume=totalArea,
                                     stdev=stdev, conf=conf, samplemethod='random')
 nSobol  = mc.integration_n_from_err(error=error, dimension=dimension, volume=totalArea,
                                     stdev=stdev, conf=conf, samplemethod='sobol')
-print(f'Number of samples needed to reach an error ≤ ±{error} at {round(conf*100, 2)}% ' +
-      f'confidence if using random vs sobol sampling: {nRandom} vs {nSobol}')
+logger.info(f'Number of samples needed to reach an error ≤ ±{error} at {round(conf*100, 2)}% '
+            f'confidence if using random vs sobol sampling: {nRandom} vs {nSobol}')
 
 # The sobol methods need to be a power of 2 for best performance and balance
 ndraws = mc.next_power_of_2(nSobol)
-print(f'Rounding up to next power of 2: {ndraws} samples')
+logger.info(f'Rounding up to next power of 2: {ndraws} samples')
 
 seed = 123639
 
@@ -89,7 +91,7 @@ def integration_example_monte_carlo_sim():
 
     resultsstr = f'π ≈ {underCurvePct*totalArea:0.5f}, n = {ndraws}, ' + \
                  f'{round(conf*100, 2)}% error = ±{err:0.5f}, stdev={stdev:0.3f}'
-    print(resultsstr)
+    logger.info(resultsstr)
 
     '''
     import matplotlib.pyplot as plt

--- a/src/monaco/__init__.py
+++ b/src/monaco/__init__.py
@@ -2,6 +2,9 @@
 from importlib import metadata
 __version__ = metadata.version(__name__)
 
+import logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 from monaco.mc_case import *
 from monaco.mc_sim import *
 from monaco.mc_var import *

--- a/template/template_monte_carlo_sim.py
+++ b/template/template_monte_carlo_sim.py
@@ -1,6 +1,7 @@
 # template_monte_carlo_sim.py
 
 import monaco as mc
+import logging
 
 # Import the statistical distributions from scipy.stats that you will be using.
 # These must be rv_discrete or rv_continuous functions.
@@ -86,13 +87,14 @@ def template_monte_carlo_sim():
     sim.runSim()
 
     # Once the sim is run, we have access to its member variables.
-    print(f'{sim.name} Runtime: {sim.runtime}')
+    logger = logging.getLogger(__name__)
+    logger.info(f'{sim.name} Runtime: {sim.runtime}')
 
     # From here we can perform further postprocessing on our results. The outvar
     # names were assigned in our postprocessing function. We expect the heads
     # bias to be near the 70% we assigned up in flip_dist.
     bias = sim.outvars['Flip Result'].vals.count('heads')/sim.ncases*100
-    print(f'Average heads bias: {bias}%')
+    logger.info(f'Average heads bias: {bias}%')
 
     # We can also quickly make some plots of our invars and outvars. The mc.plot
     # function will automatically try to figure out which type of plot is most


### PR DESCRIPTION
Replace `print` statements with `logging` for improved debuggability and adherence to best practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-73e17a1e-b375-454a-988b-da1c25fd2a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73e17a1e-b375-454a-988b-da1c25fd2a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

